### PR TITLE
Changed H33 links to use H30 technique instead #19

### DIFF
--- a/rulesets/README.md
+++ b/rulesets/README.md
@@ -26,8 +26,8 @@ The rules of the custom ruleset are grouped into 5 main categories (see below). 
 
 <li>Anchors
 <ul>
-<li>H33 Anchor Tag Title For New Windows, <a href='https://www.w3.org/TR/WCAG20-TECHS/H33.html'>H33</a> (<a href='http://www.w3.org/TR/2008/REC-WCAG20-20081211/#navigation-mechanisms-refs'>2.4.4</a>, <a href='http://www.w3.org/TR/2008/REC-WCAG20-20081211/#navigation-mechanisms-link'>2.4.9</a>)</li>
-<li>H33 Links Repeated, <a href='https://www.w3.org/TR/WCAG20-TECHS/H33.html'>H33</a> (<a href='http://www.w3.org/TR/2008/REC-WCAG20-20081211/#navigation-mechanisms-refs'>2.4.4</a>, <a href='http://www.w3.org/TR/2008/REC-WCAG20-20081211/#navigation-mechanisms-link'>2.4.9</a>)</li>
+<li>H33 Anchor Tag Title For New Windows, <a href='https://www.w3.org/TR/WCAG20-TECHS/H30.html'>H30</a> (<a href='http://www.w3.org/TR/2008/REC-WCAG20-20081211/#navigation-mechanisms-refs'>2.4.4</a>, <a href='http://www.w3.org/TR/2008/REC-WCAG20-20081211/#navigation-mechanisms-link'>2.4.9</a>)</li>
+<li>H33 Links Repeated, <a href='https://www.w3.org/TR/WCAG20-TECHS/H30.html'>H30</a> (<a href='http://www.w3.org/TR/2008/REC-WCAG20-20081211/#navigation-mechanisms-refs'>2.4.4</a>, <a href='http://www.w3.org/TR/2008/REC-WCAG20-20081211/#navigation-mechanisms-link'>2.4.9</a>)</li>
 <li>H75 Unique Anchor IDs, <a href='https://www.w3.org/TR/WCAG20-TECHS/H57.html'>H57</a> (<a href='http://www.w3.org/TR/2008/REC-WCAG20-20081211/#meaning-doc-lang-id'>3.1.1</a>)</li>
 </ul>
 </li>


### PR DESCRIPTION
Closes #19.

I simply updated the link href and text to point to H30 instead of H33. I used the GitHub online editor to do this (quick and dirty), which might explain why the section under NPM module is also showing as part of the diff...? Although it looks identical to me..